### PR TITLE
Add Research Page and Navigation Link

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -15,6 +15,9 @@ main:
   - title: "Publications"
     url: /publications/
 
+  - title: "Research"
+    url: /research/
+
   #- title: "Talks"
   #  url: /talks/    
 

--- a/_pages/research.md
+++ b/_pages/research.md
@@ -1,0 +1,75 @@
+---
+layout: single
+title: "Research"
+permalink: /research/
+author_profile: true
+---
+
+<link rel="stylesheet" href="{{ '/assets/css/research-cards.css' | relative_url }}">
+
+<div class="research-intro wordwrap">
+  <p>
+    This is an <strong>experimental layout</strong> for a research page: each project has a thumbnail on the left and title, authors, venue, and abstract on the right—similar in spirit to how <a href="https://aprilwang.me/" target="_blank" rel="noopener noreferrer">April Wang’s site</a> lists publications. The entries below use placeholder text and placeholder thumbnails so you can preview the look before wiring real papers.
+  </p>
+</div>
+
+<article class="research-paper">
+  <div class="research-paper__thumb">
+    <img src="{{ '/images/research-placeholder-a.svg' | relative_url }}" alt="Placeholder thumbnail for paper 1" width="320" height="200" loading="lazy" />
+  </div>
+  <div class="research-paper__body">
+    <h3 class="research-paper__title">
+      <a href="#">Modeling Temporal Structure in Qualitative Sequences: A Placeholder Title</a>
+    </h3>
+    <p class="research-paper__authors">Alex J. Researcher, <strong>Yuanru Tan</strong>, Jordan B. Example, Casey Q. Collaborator</p>
+    <p class="research-paper__venue">International Conference on Learning Analytics (LAK) 2026</p>
+    <p class="research-paper__abstract">
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit. This abstract is placeholder text describing a method that analyzes ordered segments of classroom discourse as networks, with the goal of revealing patterns that matter for learning. Replace this paragraph with your real contribution in two to four sentences.
+    </p>
+    <p class="research-paper__links">
+      <a href="#">Paper</a>
+      <a href="#">Project</a>
+      <a href="#">Code</a>
+    </p>
+  </div>
+</article>
+
+<article class="research-paper">
+  <div class="research-paper__thumb">
+    <img src="{{ '/images/research-placeholder-b.svg' | relative_url }}" alt="Placeholder thumbnail for paper 2" width="320" height="200" loading="lazy" />
+  </div>
+  <div class="research-paper__body">
+    <h3 class="research-paper__title">
+      <a href="#">Design Tools for Expressive Learning Analytics Dashboards (Placeholder)</a>
+    </h3>
+    <p class="research-paper__authors">Sam K. Designer, <strong>Yuanru Tan</strong>, Morgan L. Teammate</p>
+    <p class="research-paper__venue">CHI 2025 — to appear (example)</p>
+    <p class="research-paper__abstract">
+      Another placeholder abstract: we might describe a system study, design goals, and key findings about how instructors interpret visual analytics when the interface emphasizes both rigor and narrative clarity.
+    </p>
+    <p class="research-paper__links">
+      <a href="#">PDF</a>
+      <a href="#">DOI</a>
+    </p>
+  </div>
+</article>
+
+<article class="research-paper">
+  <div class="research-paper__thumb">
+    <img src="{{ '/images/research-placeholder-c.svg' | relative_url }}" alt="Placeholder thumbnail for paper 3" width="320" height="200" loading="lazy" />
+  </div>
+  <div class="research-paper__body">
+    <h3 class="research-paper__title">
+      <a href="#">Simulation-Based Assessment and “Thick” Descriptions from Log Data</a>
+    </h3>
+    <p class="research-paper__authors"><strong>Yuanru Tan</strong>, Riley N. Coauthor, Drew P. Advisor</p>
+    <p class="research-paper__venue">Journal of Learning Sciences (example venue)</p>
+    <p class="research-paper__abstract">
+      Placeholder text for a longer-form piece: open-ended simulations generate rich process data; here we sketch how qualitative coding and quantitative models can be combined—replace with your actual framing, methods, and implications.
+    </p>
+    <p class="research-paper__links">
+      <a href="#">Paper</a>
+      <a href="#">Supplement</a>
+    </p>
+  </div>
+</article>

--- a/assets/css/research-cards.css
+++ b/assets/css/research-cards.css
@@ -1,0 +1,104 @@
+/* Experimental research listing (thumbnail + text), inspired by card-style publication lists */
+
+.research-intro {
+  margin-bottom: 2rem;
+  max-width: 48rem;
+  line-height: 1.55;
+}
+
+.research-paper {
+  display: flex;
+  align-items: flex-start;
+  gap: 1.5rem;
+  padding: 1.75rem 0;
+  border-bottom: 1px solid var(--global-border-color, #dcdcdc);
+}
+
+.research-paper:first-of-type {
+  padding-top: 0.25rem;
+}
+
+.research-paper:last-of-type {
+  border-bottom: none;
+}
+
+.research-paper__thumb {
+  flex: 0 0 200px;
+  width: 200px;
+  max-width: 38vw;
+  border-radius: 8px;
+  overflow: hidden;
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.08);
+  background: #f5f5f5;
+}
+
+.research-paper__thumb img {
+  display: block;
+  width: 100%;
+  height: auto;
+  aspect-ratio: 320 / 200;
+  object-fit: cover;
+}
+
+.research-paper__body {
+  flex: 1;
+  min-width: 0;
+}
+
+.research-paper__title {
+  margin: 0 0 0.35rem;
+  font-size: 1.25rem;
+  font-weight: 600;
+  line-height: 1.35;
+}
+
+.research-paper__title a {
+  text-decoration: none;
+  border-bottom: none;
+}
+
+.research-paper__title a:hover {
+  text-decoration: underline;
+}
+
+.research-paper__authors {
+  margin: 0 0 0.35rem;
+  font-size: 0.95rem;
+  color: var(--global-text-color-light, #666);
+}
+
+.research-paper__venue {
+  margin: 0 0 0.75rem;
+  font-size: 0.9rem;
+  font-style: italic;
+  color: var(--global-text-color-light, #555);
+}
+
+.research-paper__abstract {
+  margin: 0 0 0.85rem;
+  font-size: 0.95rem;
+  line-height: 1.6;
+}
+
+.research-paper__links {
+  margin: 0;
+  font-size: 0.9rem;
+}
+
+.research-paper__links a {
+  margin-right: 1rem;
+  white-space: nowrap;
+}
+
+@media (max-width: 600px) {
+  .research-paper {
+    flex-direction: column;
+    gap: 1rem;
+  }
+
+  .research-paper__thumb {
+    flex-basis: auto;
+    width: 100%;
+    max-width: 280px;
+  }
+}

--- a/images/research-placeholder-a.svg
+++ b/images/research-placeholder-a.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="320" height="200" viewBox="0 0 320 200">
+  <defs>
+    <linearGradient id="g" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#e8f4fc"/>
+      <stop offset="100%" style="stop-color:#d4e8f7"/>
+    </linearGradient>
+  </defs>
+  <rect width="320" height="200" fill="url(#g)"/>
+  <rect x="40" y="48" width="240" height="12" rx="4" fill="#7a9aa8" opacity="0.35"/>
+  <rect x="40" y="72" width="180" height="10" rx="3" fill="#7a9aa8" opacity="0.22"/>
+  <rect x="40" y="94" width="200" height="10" rx="3" fill="#7a9aa8" opacity="0.22"/>
+  <circle cx="160" cy="142" r="28" fill="#5c8fba" opacity="0.25"/>
+</svg>

--- a/images/research-placeholder-b.svg
+++ b/images/research-placeholder-b.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="320" height="200" viewBox="0 0 320 200">
+  <defs>
+    <linearGradient id="g" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#f3f0fc"/>
+      <stop offset="100%" style="stop-color:#e8e2f5"/>
+    </linearGradient>
+  </defs>
+  <rect width="320" height="200" fill="url(#g)"/>
+  <rect x="40" y="52" width="220" height="14" rx="4" fill="#8a7a9a" opacity="0.35"/>
+  <rect x="40" y="80" width="160" height="8" rx="2" fill="#8a7a9a" opacity="0.22"/>
+  <rect x="40" y="96" width="190" height="8" rx="2" fill="#8a7a9a" opacity="0.22"/>
+  <rect x="88" y="120" width="144" height="48" rx="6" fill="#7a6aad" opacity="0.2"/>
+</svg>

--- a/images/research-placeholder-c.svg
+++ b/images/research-placeholder-c.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="320" height="200" viewBox="0 0 320 200">
+  <defs>
+    <linearGradient id="g" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#f0faf5"/>
+      <stop offset="100%" style="stop-color:#dff4e8"/>
+    </linearGradient>
+  </defs>
+  <rect width="320" height="200" fill="url(#g)"/>
+  <rect x="40" y="50" width="210" height="13" rx="4" fill="#5a9a7a" opacity="0.35"/>
+  <rect x="40" y="76" width="175" height="9" rx="2" fill="#5a9a7a" opacity="0.22"/>
+  <rect x="40" y="92" width="195" height="9" rx="2" fill="#5a9a7a" opacity="0.22"/>
+  <path d="M100 150 L160 118 L220 150 L220 170 L100 170 Z" fill="#4a9a6a" opacity="0.18"/>
+</svg>


### PR DESCRIPTION
- Introduced a new 'Research' page with an experimental layout for displaying research projects, including placeholders for thumbnails, titles, authors, venues, and abstracts.
- Updated the navigation menu to include a link to the new 'Research' page.
- Added CSS styles for the research card layout.
- Included placeholder SVG images for research thumbnails.